### PR TITLE
embedding the m2e lifecycle mapping inside the plugin jar

### DIFF
--- a/cola-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/cola-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,16 @@
+<lifecycleMappingMetadata>
+    <pluginExecutions>
+        <pluginExecution>
+            <pluginExecutionFilter>
+                <goals>
+                    <goal>compile</goal>
+                </goals>
+            </pluginExecutionFilter>
+            <action>
+                <execute>
+                    <runOnIncremental>true</runOnIncremental>
+                </execute>
+            </action>
+        </pluginExecution>
+    </pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
Hi,

It is possible starting with m2e 1.1 to embed the lifecycle mapping inside the jar instead of using a connector: https://wiki.eclipse.org/M2E_compatible_maven_plugins

I don't think it will interfere with the connector if you have it installed as well. 

For my part I removed the connector and the following mapping was enough, I did not experience any issue.

I've never written a connector for m2e before so you might know better, feel free to refuse the pull request if you don't think it is a good idea.

Cheers,
Dan
