### PR TITLE
Remove default IDE class and method

### DIFF
--- a/cola-maven-plugin-test/pom.xml
+++ b/cola-maven-plugin-test/pom.xml
@@ -55,7 +55,6 @@
             <groupId>org.cortx</groupId>
             <artifactId>cortx-maven-plugin</artifactId>
             <version>0.1.3</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -91,7 +90,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
-                    <!-- argLine>-javaagent:${cola.agent}</argLine -->
+                    <!--  argLine>-javaagent:${cola.agent}</argLine -->
                     <skip>true</skip>
                 </configuration>
                 <executions>
@@ -116,8 +115,6 @@
                 <artifactId>cola-maven-plugin</artifactId>
                 <version>${project.version}</version>
                 <configuration>
-                    <ideBaseClass>com.github.bmsantos.maven.cola.BaseColaTest</ideBaseClass>
-                    <ideTestMethod>iWillBeRemoved</ideTestMethod>
                     <includes>
                         <include>**/*Test.class</include>
                     </includes>

--- a/cola-maven-plugin-test/src/test/java/com/github/bmsantos/maven/cola/BaseColaTest.java
+++ b/cola-maven-plugin-test/src/test/java/com/github/bmsantos/maven/cola/BaseColaTest.java
@@ -2,7 +2,10 @@ package com.github.bmsantos.maven.cola;
 
 import org.junit.Test;
 
+import com.github.bmsantos.core.cola.story.annotations.IdeEnabler;
+
 public abstract class BaseColaTest {
+    @IdeEnabler
     @Test
     public void iWillBeRemoved() {
         System.out.println("This is a simple test!");

--- a/cola-maven-plugin/src/main/java/com/github/bmsantos/maven/cola/BaseColaMojo.java
+++ b/cola-maven-plugin/src/main/java/com/github/bmsantos/maven/cola/BaseColaMojo.java
@@ -37,20 +37,6 @@ public abstract class BaseColaMojo extends AbstractMojo {
     protected String targetTestDirectory;
 
     /**
-     * Base Class for IDE enabling.
-     * This is required in order to allow Cola Tests to run from IDEs such as Eclipse.
-     */
-    @Parameter
-    protected String ideBaseClass;
-
-    /**
-     * Base Class Test method for IDE enabling.
-     * The JUnit test method name to be removed.
-     */
-    @Parameter
-    protected String ideTestMethod;
-
-    /**
      * Inlude filters
      */
     @Parameter

--- a/cola-maven-plugin/src/main/java/com/github/bmsantos/maven/cola/ColaCompileMojo.java
+++ b/cola-maven-plugin/src/main/java/com/github/bmsantos/maven/cola/ColaCompileMojo.java
@@ -53,7 +53,7 @@ public class ColaCompileMojo extends BaseColaMojo {
                 project.getTestClasspathElements(), includes, excludes, deltas);
 
             try (final URLClassLoader classLoader = provider.getTargetClassLoader()) {
-                final ColaMain main = new ColaMain(ideBaseClass, ideTestMethod);
+                final ColaMain main = new ColaMain();
                 main.execute(provider);
             }
         } catch (final Throwable t) {

--- a/cola-maven-plugin/src/main/resources/cola-tests-application.properties
+++ b/cola-maven-plugin/src/main/resources/cola-tests-application.properties
@@ -13,6 +13,3 @@
 
 app.name=${project.artifactId}
 app.version=${project.version}
-
-default.ide.class=cola/ide/BaseColaTest
-default.ide.test=iWillBeRemoved

--- a/cola-maven-plugin/src/main/resources/cola-tests-messages.properties
+++ b/cola-maven-plugin/src/main/resources/cola-tests-messages.properties
@@ -10,21 +10,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-asdas
- ds jdks das d@#$ #$ 23
-3 434 #
- 43
 error.mojo=Unexpected error
 error.processing=There were errors while processing COLA JUnit Tests.
 error.failed.tests=There were %s out of %s COLA Tests that failed to process. Failed Tests: 
 error.failed.processing=Failed to process %s. Error: %s
 error.failed.process.file=Failed to process %s
-error.failed.ide=Failed to process IDE base class
 
-warn.missing.ide.test=ideBaseClassTest method not set. Will look for default JUnit Test named 'iWillBeRemoved' method and remove if available.
-
-info.missing.ide.class=ideBaseClass not set. Looking for default class.
-info.found.default.ide.class=Found default ideBaseClass class. Proceeding...
-info.missing.default.ide.class=Default class not found. Please set ideBaseClass and ideBaseClassTest properties or create cola/ide/BaseColaTest test class with test method "iWillBeRemoved".
 info.processing=Processing COLA Test: 


### PR DESCRIPTION
cola-maven-plugin no longer has the need to support for IDE class and method name settings.

Issue #31 