### PR TITLE
Allow depends on to execute a single test method

### DIFF
--- a/cola-maven-plugin-test/src/test/java/com/github/bmsantos/maven/cola/AliasTest.java
+++ b/cola-maven-plugin-test/src/test/java/com/github/bmsantos/maven/cola/AliasTest.java
@@ -1,0 +1,50 @@
+package com.github.bmsantos.maven.cola;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.github.bmsantos.core.cola.story.annotations.Assigned;
+import com.github.bmsantos.core.cola.story.annotations.Given;
+import com.github.bmsantos.core.cola.story.annotations.Then;
+import com.github.bmsantos.core.cola.story.annotations.When;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class AliasTest extends BaseColaTest {
+
+    private final String stories =
+        "Feature: Introduce greeting\n"
+            + "Scenario: Should say hello in English\n"
+            + "Given a greeter\n"
+            + "When the welcoming is announced\n"
+            + "Then the greeting will be Hello!\n"
+            + "\n"
+            + "Scenario: Deveria de dizer ola em Portugues\n"
+            + "Given um saudador\n"
+            + "When anuncia as boas vindas\n"
+            + "Then a saudacao sera Ola!";
+
+    private Map<String,String> greetings = new HashMap<String,String>() {{
+        put("greeter", "Hello!");
+        put("saudador", "Ola!");
+    }};
+
+    private String greeter;
+    private String greeting;
+
+    @Given({"a <greeter>", "um <greeter>"})
+    public void givenAGreeter(@Assigned("greeter") final String greeter) {
+        this.greeter = greeter;
+    }
+
+    @When({"the welcoming is announced","anuncia as boas vindas"})
+    public void whenAnnounced() {
+        this.greeting = greetings.get(greeter);
+    }
+
+    @Then({"the greeting will be <greeting>", "a saudacao sera <greeting>"})
+    public void thenVerifyGreeting(@Assigned("greeting") final String greeting) {
+        assertThat(this.greeting, is(greeting));
+    }
+}

--- a/cola-maven-plugin-test/src/test/java/com/github/bmsantos/maven/cola/ColaInjectableTest.java
+++ b/cola-maven-plugin-test/src/test/java/com/github/bmsantos/maven/cola/ColaInjectableTest.java
@@ -1,0 +1,43 @@
+package com.github.bmsantos.maven.cola;
+
+import com.github.bmsantos.core.cola.story.annotations.ColaInjectable;
+import com.github.bmsantos.core.cola.story.annotations.DependsOn;
+import com.github.bmsantos.core.cola.story.annotations.Then;
+import com.github.bmsantos.core.cola.story.annotations.When;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Before;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+@DependsOn(ColaInjectedTest.class)
+public class ColaInjectableTest extends BaseColaTest {
+
+    private final String stories =
+        "Feature: Inject state in depending test\n"
+            + "Scenario: Should inject state\n"
+            + "When state is increased\n"
+            + "Then the result will verify";
+
+    @ColaInjectable
+    private Integer injectableNumber;
+
+    @ColaInjectable("injected_string")
+    private String injectableString = "Hello COLA Test Dependency Injection!";
+
+    @Before
+    public void setUp() {
+        injectableNumber = new Integer(101);
+    }
+
+    @When("state is increased")
+    public void when() {
+        injectableNumber++;
+    }
+
+    @Then("the result will verify")
+    public void then() {
+        assertThat(injectableNumber, is(102));
+    }
+}

--- a/cola-maven-plugin-test/src/test/java/com/github/bmsantos/maven/cola/ColaInjectedTest.java
+++ b/cola-maven-plugin-test/src/test/java/com/github/bmsantos/maven/cola/ColaInjectedTest.java
@@ -21,8 +21,8 @@ import static org.junit.Assert.assertThat;
 public class ColaInjectedTest extends BaseColaTest {
 
     private final String stories =
-        "Feature: Introduce addition\n"
-            + "Scenario: Should add two numbers\n"
+        "Feature: Nine multiples rule\n"
+            + "Scenario: Should add to nine\n"
             + "Given an injected number\n"
             + "When multiplied by nine\n"
             + "Then the addition of its digits will be nine";

--- a/cola-maven-plugin-test/src/test/java/com/github/bmsantos/maven/cola/ColaInjectedTest.java
+++ b/cola-maven-plugin-test/src/test/java/com/github/bmsantos/maven/cola/ColaInjectedTest.java
@@ -1,0 +1,62 @@
+package com.github.bmsantos.maven.cola;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Named;
+
+import com.github.bmsantos.core.cola.story.annotations.ColaInjected;
+import com.github.bmsantos.core.cola.story.annotations.Given;
+import com.github.bmsantos.core.cola.story.annotations.Then;
+import com.github.bmsantos.core.cola.story.annotations.When;
+import com.github.bmsantos.core.cola.story.processor.StoryProcessor;
+import com.google.inject.Inject;
+import org.junit.Before;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+@ColaInjected
+public class ColaInjectedTest extends BaseColaTest {
+
+    private final String stories =
+        "Feature: Introduce addition\n"
+            + "Scenario: Should add two numbers\n"
+            + "Given an injected number\n"
+            + "When multiplied by nine\n"
+            + "Then the addition of its digits will be nine";
+
+    public List<String> executionOrder = new ArrayList<>();
+
+    @Inject
+    private Integer injectedNumber;
+
+    @Inject
+    @Named("injected_string")
+    private String injectedString;
+
+    private int result = 0;
+
+    @Given("an injected number")
+    public void givenAnInjectedNumber() {
+        System.err.println("Injected number: " + injectedNumber);
+        if (injectedNumber == null) {
+            injectedNumber = new Integer(1);
+        }
+        System.err.println("Injected string: " + injectedString);
+    }
+
+    @When("multiplied by nine")
+    public void whenA() {
+        final String s = Integer.toString(injectedNumber * 9);
+        for (int i = 0; i < s.length(); i++) {
+            result += Integer.valueOf(String.valueOf(s.charAt(i)));
+        }
+    }
+
+    @Then("the addition of its digits will be nine")
+    public void thenNine() {
+        assertThat(result, is(9));
+    }
+}

--- a/cola-maven-plugin-test/src/test/java/com/github/bmsantos/maven/cola/DependsOnTest.java
+++ b/cola-maven-plugin-test/src/test/java/com/github/bmsantos/maven/cola/DependsOnTest.java
@@ -1,5 +1,6 @@
 package com.github.bmsantos.maven.cola;
 
+import com.github.bmsantos.core.cola.story.annotations.Dependencies;
 import com.github.bmsantos.core.cola.story.annotations.DependsOn;
 import com.github.bmsantos.core.cola.story.annotations.Then;
 import com.github.bmsantos.core.cola.story.annotations.When;
@@ -14,7 +15,10 @@ public class DependsOnTest extends BaseColaTest {
             + "Then the result will verify";
 
     @When("state is checked")
-    @DependsOn({ExamplesColaTest.class, RegexColaTest.class})
+    @Dependencies({
+      @DependsOn(ExamplesColaTest.class),
+      @DependsOn(RegexColaTest.class)
+    })
     public void when() {
     }
 


### PR DESCRIPTION
Cola tests issue 45 - [Allow depends on to execute a single test method](https://github.com/bmsantos/cola-tests/issues/45).

Updated @DependsOn and introduced @Dependencies example.
